### PR TITLE
feat: hide the manifest struct

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,7 +134,7 @@ impl Bundler {
 /// The only currently supported version is 1, which encodes the data as a tuple
 /// of strings (actor names) and actor code cids.
 #[derive(Serialize_tuple, Deserialize_tuple, Clone)]
-pub struct Manifest {
+struct Manifest {
     pub version: u32,
     pub data: Cid,
 }


### PR DESCRIPTION
This doesn't need to be a part of the API, and it removes fvm_ipld_encoding from the API.