### PR TITLE
chore: release v4.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_actor_bundler"
 description = "An IPLD CAR bundling tool for Wasm bytecode"
-version = "4.1.0"
+version = "5.0.0"
 license = "MIT OR Apache-2.0"
 authors = ["Protocol Labs", "Filecoin Core Devs"]
 edition = "2021"


### PR DESCRIPTION
I think this counts as a breaking change because of the dropping of the Cbor impl, so minor seems like the right bump.