### PR TITLE
chore: update serde_ipld_dagcbor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ multihash-codetable = { version = "0.1.4", default-features = false, features = 
 async-std = "1.12.0"
 futures = { version = "0.3.28", default-features = false }
 anyhow = "1.0.72"
-serde_ipld_dagcbor = "0.4.0"
+serde_ipld_dagcbor = "0.6.1"
 serde_json = "1.0.104"
 serde = { version = "1.0.183", features = ["derive"] }
 fvm_ipld_blockstore = "0.3.0"


### PR DESCRIPTION
Removes the last copy of the old cid version.