### PR TITLE
chore: release v8.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_actor_bundler"
 description = "An IPLD CAR bundling tool for Wasm bytecode"
-version = "7.1.1"
+version = "8.0.0"
 license = "MIT OR Apache-2.0"
 authors = ["Protocol Labs", "Filecoin Core Devs"]
 edition = "2021"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.78.0"
+channel = "1.86.0"
 components = ["clippy", "rustfmt"]


### PR DESCRIPTION
This release removes all async logic & dependencies.