### PR TITLE
chore: bump deps to remove core2, upgrade to Rust 1.88.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_actor_bundler"
 description = "An IPLD CAR bundling tool for Wasm bytecode"
-version = "8.1.0"
+version = "8.0.0"
 license = "MIT OR Apache-2.0"
 authors = ["Protocol Labs", "Filecoin Core Devs"]
 edition = "2021"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fil_actor_bundler"
 description = "An IPLD CAR bundling tool for Wasm bytecode"
-version = "8.0.0"
+version = "8.1.0"
 license = "MIT OR Apache-2.0"
 authors = ["Protocol Labs", "Filecoin Core Devs"]
 edition = "2021"
@@ -12,7 +12,7 @@ keywords = ["filecoin", "web3", "wasm"]
 clap = { version = "4.5.36", default-features = false, features = ["derive", "std", "help", "usage", "error-context"] }
 fvm_ipld_car = "0.9.0"
 cid = { version = "0.11.1", default-features = false, features = ["serde"] }
-multihash-codetable = { version = "0.1.4", default-features = false, features = ["blake2b"] }
+multihash-codetable = { version = "0.2.1", default-features = false, features = ["blake2b"] }
 anyhow = "1.0.97"
 serde_ipld_dagcbor = "0.6.3"
 serde_json = "1.0.140"
@@ -22,5 +22,5 @@ fvm_ipld_encoding = "0.5.3"
 
 [dev-dependencies]
 tempfile = "3.19.1"
-rand = "0.8.5"
+rand = "0.10.1"
 num-traits = "0.2.19"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.86.0"
+channel = "1.88.0"
 components = ["clippy", "rustfmt"]

--- a/src/bin/bundler.rs
+++ b/src/bin/bundler.rs
@@ -67,7 +67,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             })
             .transpose()?;
         let cid = bundler.add_from_file(i as u32 + 1, name.clone(), cid.as_ref(), path)?;
-        println!("added actor {} with CID {}", name, cid)
+        println!("added actor {name} with CID {cid}")
     }
 
     bundler.finish()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@ impl Bundler {
             }
         }
         .with_context(|| {
-            format!("failed to put bytecode for actor {:?} into blockstore", actor_type)
+            format!("failed to put bytecode for actor {actor_type:?} into blockstore")
         })?;
         self.added.insert(actor_type, (actor_name, cid));
         Ok(cid)
@@ -128,7 +128,7 @@ struct Manifest {
 fn test_bundler() {
     use cid::multihash::Multihash;
     use fvm_ipld_car::{load_car_unchecked, CarReader};
-    use rand::Rng;
+    use rand::RngExt as _;
 
     let tmp = tempfile::tempdir().unwrap();
     let path = tmp.path().join("test_bundle.car");
@@ -141,14 +141,14 @@ fn test_bundler() {
     for i in 0..10 {
         let forced_cid = (i > 5).then(|| {
             // identity hash
-            Cid::new_v1(IPLD_RAW, Multihash::wrap(0, format!("actor-{}", i).as_bytes()).unwrap())
+            Cid::new_v1(IPLD_RAW, Multihash::wrap(0, format!("actor-{i}").as_bytes()).unwrap())
         });
         let cid = bundler
             .add_from_bytes(
                 i + 1,
                 format!("actor-{i}"),
                 forced_cid.as_ref(),
-                &rand::thread_rng().gen::<[u8; 32]>(),
+                &rand::rng().random::<[u8; 32]>(),
             )
             .unwrap();
 


### PR DESCRIPTION
This PR bumps deps and removes `core2` from deps to fix the issue that running `cargo check` without `Cargo.lock` no longer works

```
error: failed to select a version for the requirement `core2 = "^0.4.0"`
  version 0.4.0 is yanked
location searched: `rsproxy-sparse` index (which is replacing registry `crates-io`)
required by package `multihash-codetable v0.1.4`
    ... which satisfies dependency `multihash-codetable = "^0.1.4"` of package `fil_actor_bundler v8.0.0 (/home/kk/git/builtin-actors-bundler)`
``` 