### PR TITLE
ci: set up release automation triggered on Cargo.toml updates

### DIFF
--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -1,8 +1,10 @@
 name: Release Checker
 
 on:
-  pull_request_target:
-    paths: ["Cargo.toml"]
+  # Change to pull_request_target for the workflow to function correctly on PRs from forks
+  pull_request:
+    paths:
+      - "Cargo.toml"
     types: [ opened, synchronize, reopened, labeled, unlabeled ]
   workflow_dispatch:
 
@@ -16,6 +18,21 @@ concurrency:
 
 jobs:
   release-check:
-    uses: ipdxco/unified-github-workflows/.github/workflows/release-check.yml@v1
+    uses: ipdxco/unified-github-workflows/.github/workflows/release-check.yml@v1.0
+    if: ${{ github.event_name == 'workflow_dispatch' || !github.event.pull_request.head.repo.fork }}
     with:
-      sources: '["Cargo.toml"]'
+      sources: |
+        [
+          "Cargo.toml"
+        ]
+      separator: "@"
+
+  cargo-publish:
+    needs: [release-check]
+    if: needs.release-check.outputs.json != '{}'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Dry-run publish
+        run: |
+          cargo publish --dry-run

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -2,11 +2,13 @@ name: Releaser
 
 on:
   push:
-    paths: ["Cargo.toml"]
+    paths:
+      - "Cargo.toml"
   workflow_dispatch:
 
 permissions:
   contents: write
+  id-token: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.sha }}
@@ -14,8 +16,22 @@ concurrency:
 
 jobs:
   releaser:
-    uses: ipdxco/unified-github-workflows/.github/workflows/releaser.yml@v1
+    uses: ipdxco/unified-github-workflows/.github/workflows/releaser.yml@v1.0
     with:
-      sources: '["Cargo.toml"]'
+      sources: |
+        [
+          "Cargo.toml"
+        ]
+      separator: "@"
     secrets:
       UCI_GITHUB_TOKEN: ${{ secrets.UCI_GITHUB_TOKEN }}
+
+  cargo-publish:
+    needs: [releaser]
+    if: needs.releaser.outputs.json != '{}'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Publish to crates.io
+        run: |
+          cargo publish

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,34 @@
+# Releasing
+
+## Prepare
+
+To propose a new release, open a pull request with the following changes:
+
+1. Update the version in [`Cargo.toml`](https://github.com/filecoin-project/builtin-actors-bundler/blob/master/Cargo.toml): `package→version`.
+2. Update the [`CHANGELOG.md`](https://github.com/filecoin-project/builtin-actors-bundler/blob/master/CHANGELOG.md) file, set the release date & version, and add a new "Unreleased" section.
+
+When a release PR is opened or updated, the **Release Checker** GitHub Action will:
+* Verify that the version bump is correct.
+* Perform a dry-run publish (`cargo publish --dry-run`) to ensure the crate is in a valid state for release.
+* Create a draft GitHub Release and comment on the PR with a summary.
+
+## Review and Release
+
+Once the release is prepared, it'll go through a review:
+
+1. Make sure that we're _ready_ to release.
+2. Make sure that we're correctly following semver.
+3. Make sure that we're not missing anything in the changelogs.
+4. Verify that the **Release Checker** action has passed, including the "Dry-run publish" step.
+
+Finally, a repo owner will:
+
+1. Merge the release PR to master.
+2. The **Releaser** GitHub Action will automatically:
+   * Create the git tag (`vX.Y.Z`).
+   * Publish the draft GitHub Release.
+   * Publish the crate to [crates.io](https://crates.io) using `cargo publish`.
+     - Note: This repository uses **trusted publishing** via OIDC. No `CARGO_REGISTRY_TOKEN` secret is required, but the repository must be configured as a trusted publisher on crates.io.
+
+3. Verify the releases on crates.io:
+   https://crates.io/crates/fil_actor_bundler/versions


### PR DESCRIPTION
This PR sets up release automation in a similar fashion we have it set up in ref-fvm.

Releases are triggered by updating the package version in Cargo.toml. The PR flow takes care of creating tags and publishing to crates.io. Changelog is now kept in-sync manually.

## Notes

This is similar to the one we follow in ref-fvm. Part of it has also been tested in https://github.com/filecoin-project/builtin-actors-bundler/pull/33 which correctly created https://github.com/filecoin-project/builtin-actors-bundler/releases/tag/untagged-affd74090079aea92c44

TODO: 
- [x] ~~Set up trusted publishing for releaser.yml workflow.~~
